### PR TITLE
Synchronize the YAML Log with spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ main() {
     // Optionally, an instance of a Dataset Core Factory may be added as a second argument.
     const canonicalizer = new RDFCanon(n3.DataFactory);  
 
-    const input = parseYourFavouriteTriGIntoQuads();
+    const input = parseYourFavoriteTriGIntoQuads();
 
     // "normalized" is a dataset of quads with "canonical" blank node labels
     // per the specification 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -68,7 +68,7 @@ declare enum LogLevels {
 }
 
 declare interface LogItem {
-    [index: string]: string|string[]|LogItem|LogItem[]|boolean;
+    [index: string]: string|string[]|Map<string,string>|boolean|LogItem|LogItem[];
 }
 
 /**

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -71,19 +71,32 @@ declare interface LogItem {
     [index: string]: string|string[]|LogItem|LogItem[]|boolean;
 }
 
+/**
+ * Very simple Logger interface, to be used in the code. 
+ * 
+ * Implementations should follow the usual interpretation of log severity levels. E.g., if 
+ * the Logger is set up with severity level of, say, `LogLevels.info`, then the messages to `debug` should be ignored. If the 
+ * level is set to `LogLevels.warn`, then only warning and debugging messages should be recorded/displayed, etc.
+ * 
+ * For each call the arguments are:
+ * - log_point: the identification of the log point, related to the spec (in practice, this should be identical to the `id` value of the respective HTML element)
+ * - position: short description of the position of the log
+ * - otherData: the 'real' log information
+ * 
+ */
 declare interface Logger {
     log: string;
-    debug(message: string, ...otherData: LogItem[]): void;
-    warn(message: string, ...otherData: LogItem[]): void;
-    error(message: string, ...otherData: LogItem[]): void;
-    info(message: string, ...otherData: LogItem[]): void;
+    debug(log_point: string, position: string, ...otherData: LogItem[]): void;
+    warn(log_point: string, position: string, ...otherData: LogItem[]): void;
+    error(log_point: string, position: string, ...otherData: LogItem[]): void;
+    info(log_point: string, position: string, ...otherData: LogItem[]): void;
 }
 
 declare class YamlLogger implements Logger {
     log: string;
     constructor(level?: LogLevels);
-    debug(message: string, ...otherData: LogItem[]): void;
-    warn(message: string, ...otherData: LogItem[]): void;
-    error(message: string, ...otherData: LogItem[]): void;
-    info(message: string, ...otherData: LogItem[]): void;
+    debug(log_point: string, position: string, ...otherData: LogItem[]): void;
+    warn(log_point: string, position: string, ...otherData: LogItem[]): void;
+    error(log_point: string, position: string, ...otherData: LogItem[]): void;
+    info(log_point: string, position: string, ...otherData: LogItem[]): void;
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -80,23 +80,40 @@ declare interface LogItem {
  * 
  * For each call the arguments are:
  * - log_point: the identification of the log point, related to the spec (in practice, this should be identical to the `id` value of the respective HTML element)
- * - position: short description of the position of the log
+ * - position: short description of the position of the log. The string may be empty (i.e., ""), in which case it will be ignored.
  * - otherData: the 'real' log information
  * 
  */
 declare interface Logger {
     log: string;
+    log_object: LogItem;
     debug(log_point: string, position: string, ...otherData: LogItem[]): void;
     warn(log_point: string, position: string, ...otherData: LogItem[]): void;
     error(log_point: string, position: string, ...otherData: LogItem[]): void;
     info(log_point: string, position: string, ...otherData: LogItem[]): void;
+    /**
+     * Entry point for a increase in stack level. This is issued at each function entry except the top level, and at some, more complex, cycles.
+     * Needed if the logger instance intends to create recursive logs or if the structure is complex.
+     * @param label - identification of the position in the code
+     * @param extra_info - possible extra information on the level increase 
+     * @param 
+     */
+    push(label: string, extra_info ?: string, ...otherData: LogItem[]): void;
+
+    /**
+     * Counterpart of the {@link push} method.
+     */
+    pop(): void;
 }
 
 declare class YamlLogger implements Logger {
     log: string;
+    log_object: LogItem;
     constructor(level?: LogLevels);
     debug(log_point: string, position: string, ...otherData: LogItem[]): void;
     warn(log_point: string, position: string, ...otherData: LogItem[]): void;
     error(log_point: string, position: string, ...otherData: LogItem[]): void;
     info(log_point: string, position: string, ...otherData: LogItem[]): void;
+    push(label: string, extra_info ?: string, ...otherData: LogItem[]): void;
+    pop(): void;
 }

--- a/lib/canonicalization.ts
+++ b/lib/canonicalization.ts
@@ -52,7 +52,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
         }
 
         /* @@@ */ 
-        state.logger.info("ca2: Entering the canonicalization function (4.5.3 (2)).", { 
+        state.logger.info("ca.2", "Entering the canonicalization function (4.5.3 (2)).", { 
             "Bnode to quads" : bntqToLogItem(state.bnode_to_quads)
         });
         /* @@@ */ 
@@ -74,7 +74,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
             });
             
             /* @@@ */
-            state.logger.info("ca3: Calculated first degree hashes (4.5.3. (3)", {
+            state.logger.info("ca.3", "Calculated first degree hashes (4.5.3. (3)", {
                 "Hash to bnodes" : htbnToLogItem(state.hash_to_bnodes)
             });
             /* @@@ */
@@ -116,7 +116,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                 delete state.hash_to_bnodes[hash];
             }
             /* @@@ */ 
-            state.logger.info("ca4: Canonicalization function (4.5.3 (4)).", ...logItems);
+            state.logger.info("ca.4", "Canonicalization function (4.5.3 (4)).", ...logItems);
             /* @@@ */ 
            
         }
@@ -126,7 +126,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
         // because their simple, first degree hashes are not unique.
         {
             /* @@@ */
-            state.logger.info("ca5: Calculate hashes for identifiers with shared hashes (4.5.3. (5)", {
+            state.logger.info("ca.5", "Calculate hashes for identifiers with shared hashes (4.5.3. (5)).", {
                 "Hash to bnodes" : htbnToLogItem(state.hash_to_bnodes)
             });
             /* @@@ */
@@ -156,7 +156,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                 }
 
                 /* @@@ */ 
-                state.logger.info("ca5.2: Canonicalization function, after (4.5.3 (5.2))",{
+                state.logger.info("ca.5.2", "Canonicalization function, after (4.5.3 (5.2))",{
                     "computed for": hash,
                     "hash path list": ndhrToLogItem(hash_path_list)
                 });
@@ -199,7 +199,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
 
         // Step 7
         /* @@@ */ 
-        state.logger.info("c6: Leaving the canonicalization function (4.5.3)", {
+        state.logger.info("ca.6", "Leaving the canonicalization function (4.5.3)", {
             "issuer": state.canonical_issuer.toLogItem(),
         });
         /* @@@ */ 

--- a/lib/canonicalization.ts
+++ b/lib/canonicalization.ts
@@ -59,11 +59,12 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
 
         // Step 3
         {
-            /* @@@ */ state.logger.push("ca.3"); /* @@@ */
+            /* @@@ */ state.logger.push("ca.3");
+            /* @@@ */ state.logger.push("ca.3.1");
+
             // Compute a hash value for each bnode (depending on the quads it appear in)
             // In simple cases a hash value refers to one bnode only; in unlucky cases there
             // may be more. Hence the usage of the hash_to_bnodes map.
-            /* @@@ */ state.logger.push("ca.3.1"); /* @@@ */
             Object.keys(state.bnode_to_quads).forEach((n: BNodeId): void => {
                 // Step 3.1
                 const hfn: Hash = computeFirstDegreeHash(state, n)
@@ -74,7 +75,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                     state.hash_to_bnodes[hfn].push(n);
                 }
             });
-            /* @@@ */ state.logger.pop(); /* @@@ */
+            /* @@@ */ state.logger.pop();
             
             /* @@@ */
             state.logger.info("ca.3.2", "Calculated first degree hashes (4.5.3. (3))", {
@@ -135,11 +136,11 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                 "Hash to bnodes" : htbnToLogItem(state.hash_to_bnodes)
             });
             /* @@@ */
+
             const hashes: Hash[] = Object.keys(state.hash_to_bnodes).sort();
 
-            /* @@@ */
-            if (hashes.length > 0) state.logger.push("ca.5.1");
-            /* @@@ */
+            
+            /* @@@ */ if (hashes.length > 0) state.logger.push("ca.5.1");
             for (const hash of hashes) {
                 const identifier_list: BNodeId[] = state.hash_to_bnodes[hash];
                 // This cycle takes care of all problematic cases that share the same hash
@@ -149,7 +150,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                 const hash_path_list: NDegreeHashResult[] = [];
 
                 // Step 5.2
-                /* @@@ */state.logger.push("ca.5.2");
+                /* @@@ */ state.logger.push("ca.5.2");
                 for (const n of identifier_list) {
                     if (state.canonical_issuer.isSet(n)) {
                         // Step 5.2.1
@@ -164,14 +165,8 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                         hash_path_list.push(result);
                     }
                 }
-                /* @@@ */state.logger.pop();
+                /* @@@ */ state.logger.pop();
 
-                /* @@@ */ 
-                state.logger.debug("ca.5.2.extra", "Canonicalization function, after (4.5.3 (5.2)), hash past list.",{
-                    "computed for": hash,
-                    "hash path list": ndhrToLogItem(hash_path_list)
-                });
-                /* @@@ */ 
 
                 // Step 5.3
                 const ordered_hash_path_list = hash_path_list.sort((a: NDegreeHashResult,b: NDegreeHashResult): number => {
@@ -179,6 +174,12 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                     else if (a.hash > b.hash) return 1;
                     else                      return 0;
                 });
+                /* @@@ */ 
+                state.logger.debug("ca.5.2.extra", "Canonicalization function, after (4.5.3 (5.2)), ordered hash past list.",{
+                    "computed for": hash,
+                    "hash path list": ndhrToLogItem(ordered_hash_path_list)
+                });
+                /* @@@ */ 
                 for (const result of ordered_hash_path_list) {
                     // Step 5.3.1
                     for (const [existing,temporary] of result.issuer) {
@@ -186,11 +187,8 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                     }
                 }
             }
-            /* @@@ */
-            if (hashes.length > 0) state.logger.pop();
-            /* @@@ */
-            
-            /* @@@ */ state.logger.pop(); /* @@@ */
+            /* @@@ */ if (hashes.length > 0) state.logger.pop();            
+            /* @@@ */ state.logger.pop();
         }
 
         // Step 6
@@ -219,6 +217,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
             "issuer": state.canonical_issuer.toLogItem(),
         });
         /* @@@ */ 
+
         return retval.dataset;
     }
 

--- a/lib/canonicalization.ts
+++ b/lib/canonicalization.ts
@@ -59,9 +59,11 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
 
         // Step 3
         {
+            /* @@@ */ state.logger.push("ca.3"); /* @@@ */
             // Compute a hash value for each bnode (depending on the quads it appear in)
             // In simple cases a hash value refers to one bnode only; in unlucky cases there
             // may be more. Hence the usage of the hash_to_bnodes map.
+            /* @@@ */ state.logger.push("ca.3.1"); /* @@@ */
             Object.keys(state.bnode_to_quads).forEach((n: BNodeId): void => {
                 // Step 3.1
                 const hfn: Hash = computeFirstDegreeHash(state, n)
@@ -72,11 +74,13 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                     state.hash_to_bnodes[hfn].push(n);
                 }
             });
+            /* @@@ */ state.logger.pop(); /* @@@ */
             
             /* @@@ */
-            state.logger.info("ca.3", "Calculated first degree hashes (4.5.3. (3)", {
+            state.logger.info("ca.3.2", "Calculated first degree hashes (4.5.3. (3))", {
                 "Hash to bnodes" : htbnToLogItem(state.hash_to_bnodes)
             });
+            state.logger.pop();
             /* @@@ */
         }
 
@@ -126,11 +130,16 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
         // because their simple, first degree hashes are not unique.
         {
             /* @@@ */
-            state.logger.info("ca.5", "Calculate hashes for identifiers with shared hashes (4.5.3. (5)).", {
+            state.logger.push("ca.5", "Calculate hashes for identifiers with shared hashes (4.5.3. (5)).");
+            state.logger.debug("ca.5.extra", "", {
                 "Hash to bnodes" : htbnToLogItem(state.hash_to_bnodes)
             });
             /* @@@ */
             const hashes: Hash[] = Object.keys(state.hash_to_bnodes).sort();
+
+            /* @@@ */
+            if (hashes.length > 0) state.logger.push("ca.5.1");
+            /* @@@ */
             for (const hash of hashes) {
                 const identifier_list: BNodeId[] = state.hash_to_bnodes[hash];
                 // This cycle takes care of all problematic cases that share the same hash
@@ -140,6 +149,7 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                 const hash_path_list: NDegreeHashResult[] = [];
 
                 // Step 5.2
+                /* @@@ */state.logger.push("ca.5.2");
                 for (const n of identifier_list) {
                     if (state.canonical_issuer.isSet(n)) {
                         // Step 5.2.1
@@ -154,9 +164,10 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                         hash_path_list.push(result);
                     }
                 }
+                /* @@@ */state.logger.pop();
 
                 /* @@@ */ 
-                state.logger.info("ca.5.2", "Canonicalization function, after (4.5.3 (5.2))",{
+                state.logger.debug("ca.5.2.extra", "Canonicalization function, after (4.5.3 (5.2)), hash past list.",{
                     "computed for": hash,
                     "hash path list": ndhrToLogItem(hash_path_list)
                 });
@@ -175,6 +186,11 @@ export function computeCanonicalDataset(state: GlobalState, input: Quads): Quads
                     }
                 }
             }
+            /* @@@ */
+            if (hashes.length > 0) state.logger.pop();
+            /* @@@ */
+            
+            /* @@@ */ state.logger.pop(); /* @@@ */
         }
 
         // Step 6

--- a/lib/hash1DegreeQuads.ts
+++ b/lib/hash1DegreeQuads.ts
@@ -22,7 +22,7 @@ import { BNodeId, Hash, GlobalState, quadToNquad, hashNquads } from './common';
  */
  export function computeFirstDegreeHash(state: GlobalState, identifier: BNodeId): Hash {
     /* @@@ */ 
-    state.logger.info("hfdq1: Entering Hash First Degree Quads function (4.7.3)", { identifier });
+    state.logger.info("h1dg.1", "Entering Hash First Degree Quads function (4.7.3)", { identifier });
     /* @@@ */ 
 
     // Step 1
@@ -57,7 +57,7 @@ import { BNodeId, Hash, GlobalState, quadToNquad, hashNquads } from './common';
     const the_hash: Hash = hashNquads(state, nquads);
 
     /* @@@ */
-    state.logger.debug("hfdq5: Leaving Hash First Degree Quads function (4.7.3).", { 
+    state.logger.debug("h1dg.5", "Leaving Hash First Degree Quads function (4.7.3).", { 
         identifier,
         "quads" : nquads,
         "hash" : the_hash

--- a/lib/hash1DegreeQuads.ts
+++ b/lib/hash1DegreeQuads.ts
@@ -21,7 +21,8 @@ import { BNodeId, Hash, GlobalState, quadToNquad, hashNquads } from './common';
  * @returns - hash value
  */
  export function computeFirstDegreeHash(state: GlobalState, identifier: BNodeId): Hash {
-    /* @@@ */ 
+    /* @@@ */
+    state.logger.push("h1dg");
     state.logger.info("h1dg.1", "Entering Hash First Degree Quads function (4.7.3)", { identifier });
     /* @@@ */ 
 
@@ -57,11 +58,12 @@ import { BNodeId, Hash, GlobalState, quadToNquad, hashNquads } from './common';
     const the_hash: Hash = hashNquads(state, nquads);
 
     /* @@@ */
-    state.logger.debug("h1dg.5", "Leaving Hash First Degree Quads function (4.7.3).", { 
+    state.logger.info("h1dg.5", "Leaving Hash First Degree Quads function (4.7.3).", { 
         identifier,
         "quads" : nquads,
         "hash" : the_hash
     });
+    state.logger.pop();
     /* @@@ */ 
 
     return the_hash;

--- a/lib/hashNDegreeQuads.ts
+++ b/lib/hashNDegreeQuads.ts
@@ -99,7 +99,7 @@ const permutation = require('array-permutation');
     // Calculate a unique hash for all other bnodes that are immediately connected to 'identifier'
     // Note that this step will, in possible recursive calls, create additional steps for the "gossips"
     {
-        state.logger.push("hndq.3")
+        /* @@@ */ state.logger.push("hndq.3")
         for (const quad of state.bnode_to_quads[identifier]) {
             /* @@@ */ state.logger.push("hndq.3.1","", {quad: quadToNquad(quad)});
             // Step 3.1
@@ -136,7 +136,7 @@ const permutation = require('array-permutation');
 
     // Step 5
     {
-        state.logger.push("hndq.5");
+        /* @@@ */ state.logger.push("hndq.5");
 
         const hashes: Hash[] = Object.keys(Hn).sort();
         for (const hash of hashes) {
@@ -213,9 +213,7 @@ const permutation = require('array-permutation');
                 /* @@@ */
 
                 // Step 5.4.5
-                if (recursion_list.length !== 0) {
-                    state.logger.push("hndq.5.4.5.", "Starting recursion");
-                }
+                /* @@@ */ if (recursion_list.length !== 0) state.logger.push("hndq.5.4.5.");
                 for (const related of recursion_list) {
                     // Step 5.4.5.1
                     const result: NDegreeHashResult = computeNDegreeHash(state, related, issuer_copy);
@@ -241,9 +239,7 @@ const permutation = require('array-permutation');
                         continue perms;
                     }
                 }
-                if (recursion_list.length !== 0) {
-                    state.logger.pop();
-                }
+                /* @@@ */ if (recursion_list.length !== 0) state.logger.pop();
 
                 // Step 5.4.6
                 if (chosen_path.length === 0 || path < chosen_path) {
@@ -251,7 +247,7 @@ const permutation = require('array-permutation');
                     chosen_issuer = issuer_copy;
                 }
             }
-            state.logger.pop();
+            /* @@@ */ state.logger.pop();
 
             // Step 5.5.
             data_to_hash = `${data_to_hash}${chosen_path}`;

--- a/lib/hashNDegreeQuads.ts
+++ b/lib/hashNDegreeQuads.ts
@@ -28,7 +28,7 @@ const permutation = require('array-permutation');
  */
  function computeHashRelatedBlankNode(state: GlobalState, related: BNodeId, quad: rdf.Quad, issuer: IDIssuer, position: string): Hash {
     /* @@@ */ 
-    state.logger.info("hrbn1: Entering Hash Related Blank Node function (4.8.3)", {
+    state.logger.info("hrbn.1", "Entering Hash Related Blank Node function (4.8.3)", {
         "related": related,
         "quad": quadToNquad(quad),
     });
@@ -62,7 +62,7 @@ const permutation = require('array-permutation');
     const hash: Hash = computeHash(state,input);
 
     /* @@@ */ 
-    state.logger.debug("hrbn1: Leaving Hash Related Blank Node function (4.8.3 (4))", {
+    state.logger.debug("hrbn.1", "Leaving Hash Related Blank Node function (4.8.3 (4))", {
         "input to hash": input,
         hash
     });
@@ -83,7 +83,7 @@ const permutation = require('array-permutation');
  */
  export function computeNDegreeHash(state: GlobalState, identifier: BNodeId, issuer: IDIssuer): NDegreeHashResult {
     /* @@@ */ 
-    state.logger.info("hndq1: Entering Hash N-Degree Quads function (4.9.3).", {
+    state.logger.info("hndq.1", "Entering Hash N-Degree Quads function (4.9.3).", {
         identifier,
         "issuer": state.canonical_issuer.toLogItem(),
     });
@@ -115,7 +115,7 @@ const permutation = require('array-permutation');
     }
 
     /* @@@ */ 
-    state.logger.info("hndq3: Hash N-Degree Quads function (4.9.3 (3))", { 
+    state.logger.info("hndq.3", "Hash N-Degree Quads function (4.9.3 (3))", { 
         "Hash to bnodes" : Hn
     });
     /* @@@ */
@@ -127,7 +127,7 @@ const permutation = require('array-permutation');
     const hashes: Hash[] = Object.keys(Hn).sort();
     for (const hash of hashes) {
         /* @@@ */ 
-        state.logger.info("hnsq5: Hash N-Degree Quads function (4.9.3 (5)), entering loop", {
+        state.logger.info("hndq.5", "Hash N-Degree Quads function (4.9.3 (5)), entering loop", {
             hash,
             "data to hash": data_to_hash
         });
@@ -150,7 +150,7 @@ const permutation = require('array-permutation');
         const perms: BNodeId[][] = Hn[hash].length === 1 ? [Hn[hash]] : Array.from(permutation(Hn[hash]));
         perms: for (const p of perms) {
             /* @@@ */ 
-            state.logger.info("hndq5.4 Hash N-Degree Quads function (4.9.3 (5.4)), entering loop", {
+            state.logger.info("hndq.5.4", "Hash N-Degree Quads function (4.9.3 (5.4)), entering loop", {
                 p,
                 "chosen path": chosen_path
             });
@@ -168,7 +168,7 @@ const permutation = require('array-permutation');
             // Step 5.4.4
             for (const related of p) {
                 /* @@@ */ 
-                state.logger.info("hndq5.4.4 Hash N-Degree Quads function (4.9.3 (5.4.4)), entering loop", { related, path });
+                state.logger.info("hndq.5.4.4", "Hash N-Degree Quads function (4.9.3 (5.4.4)), entering loop", { related, path });
                 /* @@@ */ 
 
                 if (state.canonical_issuer.isSet(related)) {
@@ -188,7 +188,7 @@ const permutation = require('array-permutation');
             }
 
             /* @@@ */ 
-            state.logger.info("hndq5.4.5: Hash N-Degree Quads function (4.9.3 (5.4.5)), before possible recursion.", {
+            state.logger.info("hndq.5.4.5", "Hash N-Degree Quads function (4.9.3 (5.4.5)), before possible recursion.", {
                 "recursion list": recursion_list,
                 path
             });
@@ -209,7 +209,7 @@ const permutation = require('array-permutation');
                 issuer_copy = result.issuer;
 
                 /* @@@ */ 
-                state.logger.info("hndq5.4.5.4 Hash N-Degree Quads function (4.9.3 (5.4.5.4)), combine result of recursion.", {
+                state.logger.info("hndq.5.4.5.4", "Hash N-Degree Quads function (4.9.3 (5.4.5.4)), combine result of recursion.", {
                     path,
                     "issuer copy": issuer_copy.toLogItem(),
                 });
@@ -232,7 +232,7 @@ const permutation = require('array-permutation');
         data_to_hash = `${data_to_hash}${chosen_path}`;
         
         /* @@@ */ 
-        state.logger.info("hndq5.5: Hash N-Degree Quads function (4.9.3 (5.5). End of current loop with Hn hashes", {
+        state.logger.info("hndq.5.5", "Hash N-Degree Quads function (4.9.3 (5.5). End of current loop with Hn hashes", {
             "chosen path": chosen_path,
             "data to hash": data_to_hash
         });
@@ -249,7 +249,7 @@ const permutation = require('array-permutation');
     }
 
     /* @@@ */ 
-    state.logger.debug("hndq6: Leaving Hash N-Degree Quads function (4.9.3).", {
+    state.logger.debug("hndq.6", "Leaving Hash N-Degree Quads function (4.9.3).", {
         "hash": retval.hash,
         "issuer": retval.issuer.toLogItem()
     });

--- a/lib/hashNDegreeQuads.ts
+++ b/lib/hashNDegreeQuads.ts
@@ -28,6 +28,7 @@ const permutation = require('array-permutation');
  */
  function computeHashRelatedBlankNode(state: GlobalState, related: BNodeId, quad: rdf.Quad, issuer: IDIssuer, position: string): Hash {
     /* @@@ */ 
+    state.logger.push("hrbn");
     state.logger.info("hrbn.1", "Entering Hash Related Blank Node function (4.8.3)", {
         "related": related,
         "quad": quadToNquad(quad),
@@ -62,10 +63,11 @@ const permutation = require('array-permutation');
     const hash: Hash = computeHash(state,input);
 
     /* @@@ */ 
-    state.logger.debug("hrbn.1", "Leaving Hash Related Blank Node function (4.8.3 (4))", {
+    state.logger.debug("hrbn.5", "Leaving Hash Related Blank Node function (4.8.3 (4))", {
         "input to hash": input,
         hash
     });
+    state.logger.pop();
     /* @@@ */ 
 
     // Step 5
@@ -82,7 +84,8 @@ const permutation = require('array-permutation');
  * @returns
  */
  export function computeNDegreeHash(state: GlobalState, identifier: BNodeId, issuer: IDIssuer): NDegreeHashResult {
-    /* @@@ */ 
+    /* @@@ */
+    state.logger.push("hndq");
     state.logger.info("hndq.1", "Entering Hash N-Degree Quads function (4.9.3).", {
         identifier,
         "issuer": state.canonical_issuer.toLogItem(),
@@ -95,151 +98,175 @@ const permutation = require('array-permutation');
     // Step 2, 3
     // Calculate a unique hash for all other bnodes that are immediately connected to 'identifier'
     // Note that this step will, in possible recursive calls, create additional steps for the "gossips"
-    for (const quad of state.bnode_to_quads[identifier]) {
-        // Step 3.1
-        const processTerm = (term: rdf.Term, position: string): void => {
-            if (term.termType === "BlankNode" &&  term.value !== identifier) {
-                // Step 3.1.1
-                const hash = computeHashRelatedBlankNode(state, term.value, quad,  issuer, position);
-                // Step 3.1.2
-                if (Hn[hash] === undefined) {
-                    Hn[hash] = [term.value];
-                } else {
-                    Hn[hash].push(term.value)
+    {
+        state.logger.push("hndq.3")
+        for (const quad of state.bnode_to_quads[identifier]) {
+            /* @@@ */ state.logger.push("hndq.3.1","", {quad: quadToNquad(quad)});
+            // Step 3.1
+            const processTerm = (term: rdf.Term, position: string): void => {
+                /* @@@ */ state.logger.push("hndq.3.1.1","", {term: term.value});
+                if (term.termType === "BlankNode" &&  term.value !== identifier) {
+                    // Step 3.1.1
+                    const hash = computeHashRelatedBlankNode(state, term.value, quad,  issuer, position);
+                    // Step 3.1.2
+                    if (Hn[hash] === undefined) {
+                        Hn[hash] = [term.value];
+                    } else {
+                        Hn[hash].push(term.value)
+                    }
                 }
+                state.logger.pop();
             }
+            processTerm(quad.subject,'s');
+            processTerm(quad.object, 'o');
+            processTerm(quad.graph,  'g');
+            /* @@@ */ state.logger.pop();
         }
-        processTerm(quad.subject,'s');
-        processTerm(quad.object, 'o');
-        processTerm(quad.graph,  'g');
-    }
 
-    /* @@@ */ 
-    state.logger.info("hndq.3", "Hash N-Degree Quads function (4.9.3 (3))", { 
-        "Hash to bnodes" : Hn
-    });
-    /* @@@ */
+        /* @@@ */ 
+        state.logger.debug("hndq.3.extra", "Hash N-Degree Quads function (4.9.3 (3))", { 
+            "Hash to bnodes" : Hn
+        });
+        state.logger.pop();
+        /* @@@ */
+    }
 
     // Step 4
     let data_to_hash: string = '';
 
     // Step 5
-    const hashes: Hash[] = Object.keys(Hn).sort();
-    for (const hash of hashes) {
-        /* @@@ */ 
-        state.logger.info("hndq.5", "Hash N-Degree Quads function (4.9.3 (5)), entering loop", {
-            hash,
-            "data to hash": data_to_hash
-        });
-        /* @@@ */
+    {
+        state.logger.push("hndq.5");
 
-        // Step 5.1
-        data_to_hash = `${data_to_hash}${hash}`;
-
-        // Step 5.2
-        let chosen_path: string = '';
-
-        // Step 5.3
-        let chosen_issuer: IDIssuer;
-
-        // Step 5.4
-        // This is a bit unnecessarily complicated, because the
-        // 'permutation' package has a strange bug: if the array to be handled
-        // has, in fact, one element, then the result of permutations is empty...
-        //
-        const perms: BNodeId[][] = Hn[hash].length === 1 ? [Hn[hash]] : Array.from(permutation(Hn[hash]));
-        perms: for (const p of perms) {
+        const hashes: Hash[] = Object.keys(Hn).sort();
+        for (const hash of hashes) {
             /* @@@ */ 
-            state.logger.info("hndq.5.4", "Hash N-Degree Quads function (4.9.3 (5.4)), entering loop", {
-                p,
-                "chosen path": chosen_path
+            state.logger.info("hndq.5.1", "Hash N-Degree Quads function (4.9.3 (5)), entering loop", {
+                hash,
+                "data to hash": data_to_hash
             });
             /* @@@ */
 
-            // Step 5.4.1
-            let issuer_copy: IDIssuer = issuer.copy();
+            // Step 5.1
+            data_to_hash = `${data_to_hash}${hash}`;
 
-            // Step 5.4.2
-            let path: string = '';
+            // Step 5.2
+            let chosen_path: string = '';
 
-            // Step 5.4.3
-            const recursion_list: BNodeId[] = [];
+            // Step 5.3
+            let chosen_issuer: IDIssuer;
 
-            // Step 5.4.4
-            for (const related of p) {
+            // Step 5.4
+            // This is a bit unnecessarily complicated, because the
+            // 'permutation' package has a strange bug: if the array to be handled
+            // has, in fact, one element, then the result of permutations is empty...
+            //
+            state.logger.push("hndq.5.4")
+            const perms: BNodeId[][] = Hn[hash].length === 1 ? [Hn[hash]] : Array.from(permutation(Hn[hash]));
+            perms: for (const p of perms) {
                 /* @@@ */ 
-                state.logger.info("hndq.5.4.4", "Hash N-Degree Quads function (4.9.3 (5.4.4)), entering loop", { related, path });
-                /* @@@ */ 
-
-                if (state.canonical_issuer.isSet(related)) {
-                    // Step 5.4.4.1
-                    path = `${path}_:${state.canonical_issuer.issueID(related)}`;
-                } else {
-                    // Step 5.4.4.2
-                    if (!issuer_copy.isSet(related)) {
-                        recursion_list.push(related);
-                    }
-                    path = `${path}_:${issuer_copy.issueID(related)}`;
-                }
-                // Step 5.4.4.3
-                if (chosen_path.length > 0 && path.length >= chosen_path.length &&  path > chosen_path) {
-                    continue perms;
-                }
-            }
-
-            /* @@@ */ 
-            state.logger.info("hndq.5.4.5", "Hash N-Degree Quads function (4.9.3 (5.4.5)), before possible recursion.", {
-                "recursion list": recursion_list,
-                path
-            });
-            /* @@@ */
-
-            // Step 5.4.5
-            for (const related of recursion_list) {
-                // Step 5.4.5.1
-                const result: NDegreeHashResult = computeNDegreeHash(state, related, issuer_copy);
-
-                // Step 5.4.5.2
-                path = `${path}_:${issuer_copy.issueID(related)}`;
-
-                // Step 5.4.5.3
-                path = `${path}<${result.hash}>`;
-
-                // Step 5.4.5.4
-                issuer_copy = result.issuer;
-
-                /* @@@ */ 
-                state.logger.info("hndq.5.4.5.4", "Hash N-Degree Quads function (4.9.3 (5.4.5.4)), combine result of recursion.", {
-                    path,
-                    "issuer copy": issuer_copy.toLogItem(),
+                state.logger.info("hndq.5.4.1", "Hash N-Degree Quads function (4.9.3 (5.4)), entering loop", {
+                    p,
+                    "chosen path": chosen_path
                 });
                 /* @@@ */
 
-                // Step 5.4.5.5
-                if (chosen_path.length > 0 && path.length >= chosen_path.length && path > chosen_path) {
-                    continue perms;
+                // Step 5.4.1
+                let issuer_copy: IDIssuer = issuer.copy();
+
+                // Step 5.4.2
+                let path: string = '';
+
+                // Step 5.4.3
+                const recursion_list: BNodeId[] = [];
+
+                // Step 5.4.4
+                state.logger.push("hndq.5.4.4")
+                for (const related of p) {
+                    /* @@@ */ 
+                    state.logger.info("hndq.5.4.4.1", "Hash N-Degree Quads function (4.9.3 (5.4.4)), entering loop", { related, path });
+                    /* @@@ */ 
+
+                    if (state.canonical_issuer.isSet(related)) {
+                        // Step 5.4.4.1
+                        path = `${path}_:${state.canonical_issuer.issueID(related)}`;
+                    } else {
+                        // Step 5.4.4.2
+                        if (!issuer_copy.isSet(related)) {
+                            recursion_list.push(related);
+                        }
+                        path = `${path}_:${issuer_copy.issueID(related)}`;
+                    }
+                    // Step 5.4.4.3
+                    if (chosen_path.length > 0 && path.length >= chosen_path.length &&  path > chosen_path) {
+                        state.logger.pop();
+                        continue perms;
+                    }
+                }
+                state.logger.pop();
+
+                /* @@@ */ 
+                state.logger.debug("hndq.5.4.5.extra", "Hash N-Degree Quads function (4.9.3 (5.4.5)), before possible recursion.", {
+                    "recursion list": recursion_list,
+                    path
+                });
+                /* @@@ */
+
+                // Step 5.4.5
+                if (recursion_list.length !== 0) {
+                    state.logger.push("hndq.5.4.5.", "Starting recursion");
+                }
+                for (const related of recursion_list) {
+                    // Step 5.4.5.1
+                    const result: NDegreeHashResult = computeNDegreeHash(state, related, issuer_copy);
+
+                    // Step 5.4.5.2
+                    path = `${path}_:${issuer_copy.issueID(related)}`;
+
+                    // Step 5.4.5.3
+                    path = `${path}<${result.hash}>`;
+
+                    // Step 5.4.5.4
+                    issuer_copy = result.issuer;
+
+                    /* @@@ */ 
+                    state.logger.info("hndq.5.4.5.4", "Hash N-Degree Quads function (4.9.3 (5.4.5.4)), combine result of recursion.", {
+                        path,
+                        "issuer copy": issuer_copy.toLogItem(),
+                    });
+                    /* @@@ */
+
+                    // Step 5.4.5.5
+                    if (chosen_path.length > 0 && path.length >= chosen_path.length && path > chosen_path) {
+                        continue perms;
+                    }
+                }
+                if (recursion_list.length !== 0) {
+                    state.logger.pop();
+                }
+
+                // Step 5.4.6
+                if (chosen_path.length === 0 || path < chosen_path) {
+                    chosen_path   = path;
+                    chosen_issuer = issuer_copy;
                 }
             }
+            state.logger.pop();
 
-            // Step 5.4.6
-            if (chosen_path.length === 0 || path < chosen_path) {
-                chosen_path   = path;
-                chosen_issuer = issuer_copy;
-            }
+            // Step 5.5.
+            data_to_hash = `${data_to_hash}${chosen_path}`;
+            
+            /* @@@ */ 
+            state.logger.info("hndq.5.5", "Hash N-Degree Quads function (4.9.3 (5.5). End of current loop with Hn hashes", {
+                "chosen path": chosen_path,
+                "data to hash": data_to_hash
+            });
+            /* @@@ */ 
+
+            // Step 5.6
+            issuer = chosen_issuer;
         }
-
-        // Step 5.5.
-        data_to_hash = `${data_to_hash}${chosen_path}`;
-        
-        /* @@@ */ 
-        state.logger.info("hndq.5.5", "Hash N-Degree Quads function (4.9.3 (5.5). End of current loop with Hn hashes", {
-            "chosen path": chosen_path,
-            "data to hash": data_to_hash
-        });
-        /* @@@ */ 
-
-        // Step 5.6
-        issuer = chosen_issuer;
+        state.logger.pop();
     }
 
     // Step 6
@@ -249,10 +276,11 @@ const permutation = require('array-permutation');
     }
 
     /* @@@ */ 
-    state.logger.debug("hndq.6", "Leaving Hash N-Degree Quads function (4.9.3).", {
+    state.logger.info("hndq.6", "Leaving Hash N-Degree Quads function (4.9.3).", {
         "hash": retval.hash,
         "issuer": retval.issuer.toLogItem()
     });
+    state.logger.pop();
     /* @@@ */ 
     
     return retval;

--- a/lib/issueIdentifier.ts
+++ b/lib/issueIdentifier.ts
@@ -89,12 +89,11 @@ export class IDIssuer {
      * Presentation for logging.
      */
     toLogItem() : LogItem {
-        const values: string[] = [...this.issued_identifiers_map].map(([key, value]): string => `${key}=>${value}`);
         const retval: LogItem = {
             "issuer ID" : `${this.id}`,
             "prefix"    : this.identifier_prefix,
             "counter"   : `${this.identifier_counter}`,
-            "mappings"  : values
+            "mappings"  : this.issued_identifiers_map
         }
         return retval;
     }

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -73,35 +73,37 @@ export class NopLogger implements Logger {
  */
 export class YamlLogger implements Logger {
     private level: LogLevels;
-    private theLog: Log;
+    private theLog: LogItem[];
 
     constructor(level: LogLevels = LogLevels.info) {
         this.level = level;
-        this.theLog = new Map<string, LogItem>;
+        this.theLog = [];
     }
 
-    private emitMessage(mtype: "debug"|"info"|"warn"|"error", log_point: string, position: string, extras: LogItem[]): void {
+    private emitMessage(mtype: "debug"|"info"|"warn"|"error", log_id: string, position: string, extras: LogItem[]): void {
         const item: LogItem = {};
         item["log point"] = mtype === "info" ? `${position}` : `[${mtype}] ${position}`;
         item["with"] = extras;
 
-        this.theLog.set(log_point, item);
+        const full_item: LogItem = {};
+        full_item[log_id] = item;
+        this.theLog.push(full_item);
     }
 
-    debug(log_point: string, position: string, ...extras: LogItem[]): void {
-        if (this.level >= LogLevels.debug) this.emitMessage("debug", log_point, position, extras)
+    debug(log_id: string, position: string, ...extras: LogItem[]): void {
+        if (this.level >= LogLevels.debug) this.emitMessage("debug", log_id, position, extras)
     }
-    info(log_point: string, position: string, ...extras: LogItem[]): void {
-        if (this.level >= LogLevels.info) this.emitMessage("info", log_point, position, extras)
+    info(log_id: string, position: string, ...extras: LogItem[]): void {
+        if (this.level >= LogLevels.info) this.emitMessage("info", log_id, position, extras)
     }
-    warn(log_point: string, position: string, ...extras: LogItem[]): void {
-        if (this.level >= LogLevels.warn) this.emitMessage("warn", log_point, position, extras)
+    warn(log_id: string, position: string, ...extras: LogItem[]): void {
+        if (this.level >= LogLevels.warn) this.emitMessage("warn", log_id, position, extras)
     }
-    error(log_point: string, position: string, ...extras: LogItem[]): void {
-        if (this.level >= LogLevels.error) this.emitMessage("error", log_point, position, extras)
+    error(log_id: string, position: string, ...extras: LogItem[]): void {
+        if (this.level >= LogLevels.error) this.emitMessage("error", log_id, position, extras)
     }
 
-    get logObject(): Log {
+    get logObject(): LogItem[] {
         return this.theLog;
     }
 

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -34,24 +34,29 @@ export interface LogItem {
  * the Logger is set up with severity level of, say, `LogLevels.info`, then the messages to `debug` should be ignored. If the 
  * level is set to `LogLevels.warn`, then only warning and debugging messages should be recorded/displayed, etc.
  * 
+ * For each call the arguments are:
+ * - log_point: the identification of the log point, related to the spec (in practice, this should be identical to the `id` value of the respective HTML element)
+ * - position: short description of the position of the log
+ * - otherData: the 'real' log information
+ * 
  */
 export interface Logger {
     log: string;
-    debug(message: string, ...otherData: LogItem[]): void;
-    warn(message: string, ...otherData: LogItem[]): void;
-    error(message: string, ...otherData: LogItem[]): void;
-    info(message: string, ...otherData: LogItem[]): void;
+    debug(log_point: string, position: string, ...otherData: LogItem[]): void;
+    warn(log_point: string, position: string, ...otherData: LogItem[]): void;
+    error(log_point: string, position: string, ...otherData: LogItem[]): void;
+    info(log_point: string, position: string, ...otherData: LogItem[]): void;
 }
 
 /**
- * A default, no-operation logger instance, used by default. All messages are lost
+ * A default, no-operation logger instance, used by default. All messages are lost...
  */
 export class NopLogger implements Logger {
     log: string = '';
-    debug(message: string, ...otherData: LogItem[]): void {};
-    warn(message: string, ...otherData: LogItem[]): void {};
-    error(message: string, ...otherData: LogItem[]): void {};
-    info(message: string, ...otherData: LogItem[]): void {};
+    debug(log_point: string, position: string, ...otherData: LogItem[]): void {};
+    warn(log_point: string, position: string, ...otherData: LogItem[]): void {};
+    error(log_point: string, position: string, ...otherData: LogItem[]): void {};
+    info(log_point: string, position: string, ...otherData: LogItem[]): void {};
 }
 
 
@@ -66,37 +71,34 @@ export class NopLogger implements Logger {
  */
 export class YamlLogger implements Logger {
     private level: LogLevels;
-    private theLog: LogItem[];
+    private theLog: LogItem;
 
     constructor(level: LogLevels = LogLevels.info) {
         this.level = level;
-        this.theLog = [];
+        this.theLog = {};
     }
 
-    private emitMessage(mtype: "debug"|"info"|"warn"|"error", msg: string, extras: LogItem[]): void {
-        const item: LogItem = {
-            "log point" : mtype === "info" ? `${msg}` : `[${mtype}] ${msg}`
-        }
-        if (extras.length > 0) {
-            item["with"] = extras;
-        }
-        this.theLog.push(item);
+    private emitMessage(mtype: "debug"|"info"|"warn"|"error", log_point: string, position: string, extras: LogItem[]): void {
+        const item: LogItem = {};
+        item["log point"] = mtype === "info" ? `${position}` : `[${mtype} ${position}]`;
+        item["with"] = extras;
+        this.theLog[log_point] = item;
     }
 
-    debug(msg: string, ...extras: LogItem[]): void {
-        if (this.level >= LogLevels.debug) this.emitMessage("debug", msg, extras)
+    debug(log_point: string, position: string, ...extras: LogItem[]): void {
+        if (this.level >= LogLevels.debug) this.emitMessage("debug", log_point, position, extras)
     }
-    info(msg: string, ...extras: LogItem[]): void {
-        if (this.level >= LogLevels.info) this.emitMessage("info", msg, extras)
+    info(log_point: string, position: string, ...extras: LogItem[]): void {
+        if (this.level >= LogLevels.info) this.emitMessage("info", log_point, position, extras)
     }
-    warn(msg: string, ...extras: LogItem[]): void {
-        if (this.level >= LogLevels.warn) this.emitMessage("warn", msg, extras)
+    warn(log_point: string, position: string, ...extras: LogItem[]): void {
+        if (this.level >= LogLevels.warn) this.emitMessage("warn", log_point, position, extras)
     }
-    error(msg: string, ...extras: LogItem[]): void {
-        if (this.level >= LogLevels.error) this.emitMessage("error", msg, extras)
+    error(log_point: string, position: string, ...extras: LogItem[]): void {
+        if (this.level >= LogLevels.error) this.emitMessage("error", log_point, position, extras)
     }
 
-    get logObject(): LogItem[] {
+    get logObject(): LogItem {
         return this.theLog
     }
 

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -1,6 +1,6 @@
 /**
- * Simple logging environment, used by the rest of the code. By default, no logging occurs; the user can set his/her own
- * logging environment. This module also includes a logger to dump the results into a YAML file.
+ * Logging environment, used by the rest of the code. By default, no logging occurs; the user can set his/her own
+ * logging environment. This module also includes a logger to create a recursive log in YAML.
  * 
  * @copyright Ivan Herman 2023
  * 
@@ -21,7 +21,7 @@ export enum LogLevels {
 };
 
 /**
- * And individual log item. A complete log is, conceptually, an array of such log reports.
+ * And individual log item.
  */
 export interface LogItem {
     [index: string]: string|string[]|Map<string,string>|boolean|LogItem|LogItem[];
@@ -43,22 +43,74 @@ export type Log = Map<string,LogItem>;
  * 
  */
 export interface Logger {
+    /** The current log */
+    log_object: LogItem;
+
+    /** The current log, in some string representation */
     log: string;
+
+    /**
+     * Debug level log.
+     * 
+     * @param log_point 
+     * @param position 
+     * @param otherData 
+     */
     debug(log_point: string, position: string, ...otherData: LogItem[]): void;
+
+    /**
+     * Warning level log.
+     * 
+     * @param log_point 
+     * @param position 
+     * @param otherData 
+     */
     warn(log_point: string, position: string, ...otherData: LogItem[]): void;
+
+    /**
+     * Error level log.
+     * 
+     * @param log_point 
+     * @param position 
+     * @param otherData 
+     */
     error(log_point: string, position: string, ...otherData: LogItem[]): void;
+
+    /**
+     * Information level log.
+     * 
+     * @param log_point 
+     * @param position 
+     * @param otherData 
+     */
     info(log_point: string, position: string, ...otherData: LogItem[]): void;
+
+    /**
+     * Entry point for recursive call. This is issued at each function entry except the top level, and at some, more complex cycles.
+     * Needed if the logger instance intends to create recursive logs.
+     * @param label - identification of the position in the code
+     * @param position
+     */
+    push(label: string, position ?: string, ...otherData: LogItem[]): void;
+
+    /**
+     * Counterpart of the {@link push} method.
+     */
+    pop(): void;
 }
 
 /**
- * A default, no-operation logger instance, used by default. All messages are lost...
+ * A default, no-operation logger instance, used by default. All methods are empty, ie, all messages are lost...
  */
 export class NopLogger implements Logger {
     log: string = '';
+    log_object: LogItem = {};
     debug(log_point: string, position: string, ...otherData: LogItem[]): void {};
     warn(log_point: string, position: string, ...otherData: LogItem[]): void {};
     error(log_point: string, position: string, ...otherData: LogItem[]): void {};
     info(log_point: string, position: string, ...otherData: LogItem[]): void {};
+    push(label: string, position ?: string, ...otherData: LogItem[]): void {};
+    pop(): void {};
 }
 
 
@@ -66,28 +118,39 @@ export class NopLogger implements Logger {
  * Simple logger, storing the individual log messages as an array of {@link LogItem} objects. The logger
  * follows the recommendations on severity levels as described in {@link Logger}.
  * 
- * The final log can be retrieved either as the array of Objects via the `logObject`, or
+ * The final log can be retrieved either as the array of Objects via the `log_object`, or
  * as a YAML string via the `log` attributes, respectively.
  * 
  * By default, the logger level is set to `LogLevels.info`.
  */
 export class YamlLogger implements Logger {
     private level: LogLevels;
-    private theLog: LogItem[];
+
+    private top_log: LogItem = {};
+    private current_log: LogItem[];
+    private log_stack: LogItem[][] = [];
+
 
     constructor(level: LogLevels = LogLevels.info) {
         this.level = level;
-        this.theLog = [];
+
+        const ca_level: LogItem[] = [];
+        this.top_log["ca"] = ca_level;
+        this.current_log = ca_level;
     }
 
     private emitMessage(mtype: "debug"|"info"|"warn"|"error", log_id: string, position: string, extras: LogItem[]): void {
         const item: LogItem = {};
-        item["log point"] = mtype === "info" ? `${position}` : `[${mtype}] ${position}`;
-        item["with"] = extras;
+        if (position !== '') {
+            item["log point"] = mtype === "info" ? `${position}` : `[${mtype}] ${position}`;
+        }
+        if (extras.length !== 0) {
+            item["with"] = extras;
+        }
 
         const full_item: LogItem = {};
         full_item[log_id] = item;
-        this.theLog.push(full_item);
+        this.current_log.push(full_item);
     }
 
     debug(log_id: string, position: string, ...extras: LogItem[]): void {
@@ -103,15 +166,41 @@ export class YamlLogger implements Logger {
         if (this.level >= LogLevels.error) this.emitMessage("error", log_id, position, extras)
     }
 
-    get logObject(): LogItem[] {
-        return this.theLog;
+    push(label: string, position ?: string, ...extras: LogItem[]): void {
+        const new_level: LogItem[] = [];
+        const new_level_ref: LogItem = {};
+
+        new_level_ref[label] = new_level;
+        if (position && position !== "") {
+            new_level.push({
+                "push on stack": position
+            })
+        }
+        if (extras.length !== 0) {
+            new_level.push({
+                "with": extras
+            });
+        }
+
+        this.current_log.push(new_level_ref);
+
+        this.log_stack.push(this.current_log);
+        this.current_log = new_level;
+    }
+
+    pop(): void {
+        this.current_log = this.log_stack.pop();
+    }
+
+    get log_object(): LogItem {
+        return this.top_log;
     }
 
     get log(): string {
-        return yaml.stringify(this.theLog);
+        return yaml.stringify(this.log_object, { aliasDuplicateObjects: false });
     }
 }
-
+ 
 /**
  * Return a log item version of a `BNodeToQuads` instance, used to build up a full log message.
  * 

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -27,6 +27,8 @@ export interface LogItem {
     [index: string]: string|string[]|LogItem|LogItem[]|boolean;
 }
 
+export type Log = Map<string,LogItem>;
+
 /**
  * Very simple Logger interface, to be used in the code. 
  * 
@@ -71,18 +73,19 @@ export class NopLogger implements Logger {
  */
 export class YamlLogger implements Logger {
     private level: LogLevels;
-    private theLog: LogItem;
+    private theLog: Log;
 
     constructor(level: LogLevels = LogLevels.info) {
         this.level = level;
-        this.theLog = {};
+        this.theLog = new Map<string, LogItem>;
     }
 
     private emitMessage(mtype: "debug"|"info"|"warn"|"error", log_point: string, position: string, extras: LogItem[]): void {
         const item: LogItem = {};
-        item["log point"] = mtype === "info" ? `${position}` : `[${mtype} ${position}]`;
+        item["log point"] = mtype === "info" ? `${position}` : `[${mtype}] ${position}`;
         item["with"] = extras;
-        this.theLog[log_point] = item;
+
+        this.theLog.set(log_point, item);
     }
 
     debug(log_point: string, position: string, ...extras: LogItem[]): void {
@@ -98,8 +101,8 @@ export class YamlLogger implements Logger {
         if (this.level >= LogLevels.error) this.emitMessage("error", log_point, position, extras)
     }
 
-    get logObject(): LogItem {
-        return this.theLog
+    get logObject(): Log {
+        return this.theLog;
     }
 
     get log(): string {

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -24,7 +24,7 @@ export enum LogLevels {
  * And individual log item. A complete log is, conceptually, an array of such log reports.
  */
 export interface LogItem {
-    [index: string]: string|string[]|LogItem|LogItem[]|boolean;
+    [index: string]: string|string[]|Map<string,string>|boolean|LogItem|LogItem[];
 }
 
 export type Log = Map<string,LogItem>;


### PR DESCRIPTION
Gregg,

I have modified the YAML output to bring it closer to what we discussed. Here is the current output for the simple example:

```yaml
- ca.2:
    log point: Entering the canonicalization function (4.5.3 (2)).
    with:
      - Bnode to quads:
          e0:
            - <http://example.com/#p> <http://example.com/#q> _:e0 .
            - _:e0 <http://example.com/#s> <http://example.com/#u> .
          e1:
            - <http://example.com/#p> <http://example.com/#r> _:e1 .
            - _:e1 <http://example.com/#t> <http://example.com/#u> .
- h1dg.1:
    log point: Entering Hash First Degree Quads function (4.7.3)
    with:
      - identifier: e0
- h1dg.1:
    log point: Entering Hash First Degree Quads function (4.7.3)
    with:
      - identifier: e1
- ca.3:
    log point: Calculated first degree hashes (4.5.3. (3)
    with:
      - Hash to bnodes:
          - hash: 21d1dd5ba21f3dee9d76c0c00c260fa6f5d5d65315099e553026f4828d0dc77a
            bnodes:
              - e0
          - hash: 6fa0b9bdb376852b5743ff39ca4cbf7ea14d34966b2828478fbf222e7c764473
            bnodes:
              - e1
- ca.4:
    log point: Canonicalization function (4.5.3 (4)).
    with:
      - identifier: e0
        hash: 21d1dd5ba21f3dee9d76c0c00c260fa6f5d5d65315099e553026f4828d0dc77a
        canonical id: c14n0
      - identifier: e1
        hash: 6fa0b9bdb376852b5743ff39ca4cbf7ea14d34966b2828478fbf222e7c764473
        canonical id: c14n1
- ca.5:
    log point: Calculate hashes for identifiers with shared hashes (4.5.3. (5)).
    with:
      - Hash to bnodes: []
- ca.6:
    log point: Leaving the canonicalization function (4.5.3)
    with:
      - issuer:
          issuer ID: "1235"
          prefix: c14n
          counter: "2"
          mappings:
            - e0=>c14n0
            - e1=>c14n1
```