### PR TITLE
Move to @rdfjs/types

### DIFF
--- a/lib/canonicalization.ts
+++ b/lib/canonicalization.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import * as rdf from 'rdf-js';
+import * as rdf from '@rdfjs/types';
 import {
     GlobalState, BNodeId, Hash, Quads, NDegreeHashResult, concatNquads,
     quadsToNquads, parseNquads, InputDataset, C14nResult

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import * as rdf from 'rdf-js';
+import * as rdf from '@rdfjs/types';
 import * as n3 from 'n3';
 
 import { IDIssuer }        from './issueIdentifier';

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -8,7 +8,6 @@
 
 import * as rdf from 'rdf-js';
 import * as n3 from 'n3';
-import * as CryptoJS from 'crypto-js';
 
 import { IDIssuer }        from './issueIdentifier';
 import { nquads }          from '@tpluscode/rdf-string';

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,87 @@
+"use strict";
+/**
+ * Configuration constants. System administrators may want to modify these parameters,
+ * although they should do it with care.
+ *
+ * Applications relying on the library may provide a callback to modify the configuration data. The `extras` directory
+ * on the [github repository](https://github.com/iherman/rdfjs-c14n) includes such a callback for the `node.js` platform.
+ *
+ * @copyright Ivan Herman 2023
+ *
+ * @packageDocumentation
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.defaultConfigData = exports.ENV_HASH_ALGORITHM = exports.ENV_COMPLEXITY = exports.AVAILABLE_HASH_ALGORITHMS = exports.HASH_ALGORITHM = exports.DEFAULT_MAXIMUM_COMPLEXITY = void 0;
+/**
+ * Default maximal complexity value. Algorithmically, this number is multiplied
+ * with the number of bnodes in a given dataset, thereby yielding the maximum times
+ * the `computeNDegreeHash` function can be called (this function is invoked
+ * in only a few cases when there two blank nodes get the same hash value in the
+ * first pass of the algorithm).
+ *
+ * Setting this number to a reasonably low number (say, 30),
+ * ensures that some "poison graphs" would not result in an unreasonably long canonicalization process.
+ * See the [security consideration section](https://www.w3.org/TR/rdf-canon/ #security-considerations)
+ * in the specification.
+ *
+ * @readonly
+ *
+ */
+exports.DEFAULT_MAXIMUM_COMPLEXITY = 50;
+/**
+ * The default hash algorithm's name. If changed, it should be one of the keys in the
+ * separate {@link AVAILABLE_HASH_ALGORITHMS} object.
+ *
+ * Care should be taken if changing this constant. The formal specification of RDFC-1.0
+ * _requires_ the value of "SHA256". If a different hash function is used, the
+ * canonicalization results will not be interoperable with other implementations/installations.
+ *
+ * @readonly
+ *
+ */
+exports.HASH_ALGORITHM = "sha256";
+/**
+ * List of available hash algorithms defined by the WebCrypto API standard as of November 2021.
+ * The user has the possibility to change the hash algorithm to be used instead of the
+ * default one.
+ *
+ * Note that the list includes the alternative formats with or without the '-' character,
+ * and the interface function for setting the algorithm is case insensitive.
+ *
+ * @readonly
+ *
+ */
+exports.AVAILABLE_HASH_ALGORITHMS = {
+    "sha1": "SHA-1",
+    "sha256": "SHA-256",
+    "sha384": "SHA-384",
+    "sha512": "SHA-256",
+    "sha-1": "SHA-1",
+    "sha-256": "SHA-256",
+    "sha-384": "SHA-384",
+    "sha-512": "SHA-256",
+};
+/**
+ * Environment variable to set/change the maximum complexity
+ *
+ * @readonly
+ *
+ */
+exports.ENV_COMPLEXITY = "c14n_complexity";
+/**
+ * Environment variable to set/change the default hash algorithm
+ */
+exports.ENV_HASH_ALGORITHM = "c14n_hash";
+/**
+ * A default callback, returning the built-in configuration data. Application developers may
+ * create an alternative callback with a more user-friendly way to set the configuration values.
+ *
+ * @returns
+ */
+function defaultConfigData() {
+    return {
+        c14n_complexity: exports.DEFAULT_MAXIMUM_COMPLEXITY,
+        c14n_hash: exports.HASH_ALGORITHM,
+    };
+}
+exports.defaultConfigData = defaultConfigData;

--- a/lib/hash1DegreeQuads.ts
+++ b/lib/hash1DegreeQuads.ts
@@ -6,7 +6,7 @@
  * @packageDocumentation
  */
 
-import * as rdf from 'rdf-js';
+import * as rdf from '@rdfjs/types';
 import { BNodeId, Hash, GlobalState, quadToNquad, hashNquads } from './common';
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "rdfjs-c14n",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rdfjs-c14n",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "W3C-20150513",
       "dependencies": {
         "@tpluscode/rdf-string": "^0.2.27",
-        "@types/rdf-js": "^4.0.2",
         "array-permutation": "^0.2.0",
         "n3": "^1.16.3",
         "rdf-js": "^4.0.2",
         "yaml": "^2.2.1"
       },
       "devDependencies": {
+        "@rdfjs/types": "^1.1.0",
         "@types/commander": "^2.12.2",
         "@types/n3": "^1.10.4",
         "@types/node": "^20.2.5",
@@ -449,15 +449,6 @@
       "version": "20.2.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
       "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
-    },
-    "node_modules/@types/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
-      "deprecated": "This is a stub types definition. rdf-js provides its own type definitions, so you do not need this installed.",
-      "dependencies": {
-        "rdf-js": "*"
-      }
     },
     "node_modules/@types/rdfjs__namespace": {
       "version": "2.0.0",
@@ -2810,14 +2801,6 @@
       "version": "20.2.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
       "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ=="
-    },
-    "@types/rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-soR/+RMogGiDU1lrpuQl5ZL55/L1eq/JlR2dWx052Uh/RYs9okh3XZHFlIJXHZqjqyjEn4WdbOMfBj7vvc2WVQ==",
-      "requires": {
-        "rdf-js": "*"
-      }
     },
     "@types/rdfjs__namespace": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@tpluscode/rdf-string": "^0.2.27",
         "array-permutation": "^0.2.0",
         "n3": "^1.16.3",
-        "rdf-js": "^4.0.2",
         "yaml": "^2.2.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "@tpluscode/rdf-string": "^0.2.27",
     "array-permutation": "^0.2.0",
     "n3": "^1.16.3",
-    "rdf-js": "^4.0.2",
     "yaml": "^2.2.1"
   },
   "devDependencies": {
+    "rdf-js": "^4.0.2",
     "@rdfjs/types": "^1.1.0",
     "@types/commander": "^2.12.2",
     "@types/n3": "^1.10.4",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,10 @@
     "@tpluscode/rdf-string": "^0.2.27",
     "array-permutation": "^0.2.0",
     "n3": "^1.16.3",
-    "yaml": "^2.2.1"
+    "yaml": "^2.2.1",
+    "@rdfjs/types": "^1.1.0"
   },
   "devDependencies": {
-    "rdf-js": "^4.0.2",
-    "@rdfjs/types": "^1.1.0",
     "@types/commander": "^2.12.2",
     "@types/n3": "^1.10.4",
     "@types/node": "^20.2.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rdfjs-c14n",
-  "version": "3.0.0",
-  "date": "2023-11-23",
+  "version": "3.0.1",
+  "date": "2024-02-07",
   "description": "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces",
   "homepage": "https://github.com/iherman/rdfjs-c14n",
   "repository": {
@@ -36,13 +36,13 @@
   "license": "W3C-20150513",
   "dependencies": {
     "@tpluscode/rdf-string": "^0.2.27",
-    "@types/rdf-js": "^4.0.2",
     "array-permutation": "^0.2.0",
     "n3": "^1.16.3",
     "rdf-js": "^4.0.2",
     "yaml": "^2.2.1"
   },
   "devDependencies": {
+    "@rdfjs/types": "^1.1.0",
     "@types/commander": "^2.12.2",
     "@types/n3": "^1.10.4",
     "@types/node": "^20.2.5",

--- a/testing/run/rdfn3.ts
+++ b/testing/run/rdfn3.ts
@@ -7,7 +7,7 @@
  */
 
 import * as n3 from 'n3';
-import * as rdf from 'rdf-js';
+import * as rdf from '@rdfjs/types';
 import { promises as fs } from 'fs';
 import { nquads } from '@tpluscode/rdf-string';
 


### PR DESCRIPTION
This is to fix #9

Also: there was a superfluous reference to crypto-js, which is no longer used (using the WebCrypto implementation instead); this was also removed on the fly...