### PR TITLE
Copying generator content to internal datastore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# Version 3.1.3
+
+- More careful with the initial choice on whether the input dataset must be copied to an internal store or not (triggered by a bug whereby a dataset through a generator function would not have worked)
+
+
 # Version 3.1.1
 
 - On the advice of @jeswr the turtle parser is now based on the streaming parser of n3, avoiding an unnecessary "buffer" like array. The same is true for the test runner.

--- a/README.md
+++ b/README.md
@@ -35,11 +35,18 @@ The canonicalization process can be invoked by
   - issued_identifier_map: a Map object, mapping the original blank node id-s (as used in the input) to their canonical equivalents
   - bnode_identifier_map: Map object, mapping a blank node to its (canonical) blank node id
 
-> Note that the Iterable<rdf.Qad> instance in the input of these calls is expected to be a _set_ of quads, i.e., it should not have repeated entries. By default, this is not checked (this may be a costly operation for large RDF graphs), but the canonicalization methods can be invoked with an additional boolean flag instructing the system to "de-duplicate" (essentially, create a new dataset instance where duplicate quads are removed).
+> Note that the Iterable<rdf.Qad> instance, in the input of these calls, is expected to be a _set_ of quads, i.e., it should not have repeated entries. This is not directly checked by 
+> the system but, in some cases, the input graph is copied into an internal store, thereby de-duplicating tests. Because this can be a costly operation for large Graph, this can be
+> controlled by the user through the optional usage of a boolean parameter `copy`. The effects are as follows:
+>
+> - If the value of `copy` is set, then the input is copied or not to an internal store if the value is `true`, respectively `false`.
+> - If the value of `copy` is not set, the input is copied ***unless*** the object implements the [rdf Dataset Core interface](https://rdf.js.org/dataset-spec/#datasetcore-interface). 
 > 
-> If the input is a document to parsed by the system, duplicate quads are filtered out automatically.
+> What it means in practice is that if the user uses a standard RDF Data store, the quads are considered to be unique, and no copy occurs. Otherwise (if for example, and array of quads is used) the quads are copied.
+> 
+> If the input is a document is to parsed by the system, duplicate quads are filtered out automatically.
 
-The separate [testing folder](https://github.com/iherman/rdfjs-c14n/tree/main/testing) includes a tiny application that runs some local tests, and can be used as an example for the additional packages that are required. 
+The separate [testing folder](https://github.com/iherman/rdfjs-c14n/tree/main/testing) includes a tiny application that runs some local tests, and can be used as an example for the additional packages that are required. See also the separate [tester repository](https://github.com/iherman/rdfjs-c14n-tester) that runs the official test suite set up by the W3C Working Group.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -35,18 +35,22 @@ The canonicalization process can be invoked by
   - issued_identifier_map: a Map object, mapping the original blank node id-s (as used in the input) to their canonical equivalents
   - bnode_identifier_map: Map object, mapping a blank node to its (canonical) blank node id
 
-> Note that the Iterable<rdf.Qad> instance, in the input of these calls, is expected to be a _set_ of quads, i.e., it should not have repeated entries. This is not directly checked by 
-> the system but, in some cases, the input graph is copied into an internal store, thereby de-duplicating tests. Because this can be a costly operation for large Graph, this can be
-> controlled by the user through the optional usage of a boolean parameter `copy`. The effects are as follows:
->
-> - If the value of `copy` is set, then the input is copied or not to an internal store if the value is `true`, respectively `false`.
-> - If the value of `copy` is not set, the input is copied ***unless*** the object implements the [rdf Dataset Core interface](https://rdf.js.org/dataset-spec/#datasetcore-interface). 
-> 
-> What it means in practice is that if the user uses a standard RDF Data store, the quads are considered to be unique, and no copy occurs. Otherwise (if for example, and array of quads is used) the quads are copied.
-> 
-> If the input is a document is to parsed by the system, duplicate quads are filtered out automatically.
+### Copying the input quads
+
+The `Iterable<rdf.Qad>` input instance is expected to be a _set_ of quads, i.e., it should not include repeated entries. This is not checked by 
+the process. Usually, the input quads are copied into an internal store, thereby de-duplicating them. Because this can be a costly operation
+for large dataset, it can be controlled through an additional, optional, boolean parameter `copy`. The effects are as follows:
+
+- If the value of `copy` is set, and its value is `true`, the input quads are copied to an internal store. If the value is `false`, the quads are used directly.
+- If the value of `copy` is not set, the input is copied to an internal store ***unless*** the object implements the [RDF DatasetCore interface](https://rdf.js.org/dataset-spec/#datasetcore-interface).
+
+If the input is a string serializing a Dataset in Turtle/TriG format, the input is parsed, and duplicate quads are filtered out automatically.
+
+Note that the value of `copy` ***must not*** be set to `false` if the input is a generator function (even if the generator function avoids duplicate quads).
 
 The separate [testing folder](https://github.com/iherman/rdfjs-c14n/tree/main/testing) includes a tiny application that runs some local tests, and can be used as an example for the additional packages that are required. See also the separate [tester repository](https://github.com/iherman/rdfjs-c14n-tester) that runs the official test suite set up by the W3C Working Group.
+
+All the examples below ignore the `copy` argument.
 
 ## Installation
 
@@ -80,7 +84,7 @@ import * as rdf from '@rdfjs/types';;
 // export type InputQuads = Iterable<rdf.Quad>;
 import {RDFC10, Quads, InputQuads } from 'rdf-c14n';
 
-async main() {
+async function main(): Promise<void> {
     // Any implementation of the data factory will do in the call below.
     // By default, the Data Factory of the n3 package (i.e., the argument in the call
     // below is not strictly necessary).

--- a/index.ts
+++ b/index.ts
@@ -158,14 +158,15 @@ export class RDFC10 {
      * @throws - RangeError, if the complexity of the graph goes beyond the set complexity number. See {@link maximum_complexity_number}.
      * 
      * @param input_dataset 
-     * @param deduplicate - whether duplicate quads should be removed from the input (optional, defaults to `false`)
+     * @param copy - whether the input should be copied to a local store (e.g., if the input is a generator, or the uniqueness of quads are not guaranteed). If this
+     * parameter is not used (i.e., value is `undefined`) the copy is always done _unless_ the input is an `rdf.DatasetCore` instance.
      * @returns - N-Quads document using the canonical ID-s.
      * 
      * @async
      * 
      */
-    async canonicalize(input_dataset: InputDataset, deduplicate = false): Promise<string> {
-        return (await this.c14n(input_dataset, deduplicate)).canonical_form;
+    async canonicalize(input_dataset: InputDataset, copy: boolean | undefined = undefined): Promise<string> {
+        return (await this.c14n(input_dataset, copy)).canonical_form;
     }
 
     /**
@@ -185,13 +186,14 @@ export class RDFC10 {
      * @throws - RangeError, if the complexity of the graph goes beyond the set complexity number. See {@link maximum_complexity_number}.
      *
      * @param input_dataset 
-     * @param deduplicate - whether duplicate quads should be removed from the input (optional, defaults to `false`)
+     * @param copy - whether the input should be copied to a local store (e.g., if the input is a generator, or the uniqueness of quads are not guaranteed). If this
+     * parameter is not used (i.e., value is `undefined`) the copy is always done _unless_ the input is an `rdf.DatasetCore` instance.
      * @returns - Detailed results of the canonicalization
      * 
      * @async
      */
-    async c14n(input_dataset: InputDataset, deduplicate = false): Promise<C14nResult> {
-        return computeCanonicalDataset(this.state, input_dataset, deduplicate);
+    async c14n(input_dataset: InputDataset, copy: boolean | undefined = undefined): Promise<C14nResult> {
+        return computeCanonicalDataset(this.state, input_dataset, copy);
     }
 
     /**

--- a/lib/canonicalization.ts
+++ b/lib/canonicalization.ts
@@ -51,7 +51,7 @@ const createBidMap = (graph: Quads): ReadonlyMap<rdf.BlankNode, BNodeId> => {
  * @param input
  * @param copy - whether the input should be copied to a local store (e.g., if the input is a generator, or the uniqueness of quads are not guaranteed). If this
  * parameter is not used (i.e., value is `undefined`) the copy is always done _unless_ the input is an `rdf.DatasetCore` instance.
- * @returns - A semantically identical set of Quads, with canonical BNode labels, plus other information.
+ * @returns - A semantically identical set of Quads using canonical BNode labels, plus other information.
  * 
  * @async
  */

--- a/lib/canonicalization.ts
+++ b/lib/canonicalization.ts
@@ -60,16 +60,12 @@ export async function computeCanonicalDataset(state: GlobalState, input: InputDa
         if (typeof input === 'string') {
             return await parseNquads(input as string);
         } else {
-            const createCopy = (): InputQuads => {
+            if (copy ?? !isQuads(input)) {
                 const retval = new n3.Store();
                 for (const quad of input) retval.add(quad);
                 return retval;
-            };
-            if (copy === undefined) {
-                return isQuads(input) ? input : createCopy();
-            } else {
-                return copy ? createCopy() : input;
-            }
+            }  
+            return input;
         }
     }
 

--- a/lib/canonicalization.ts
+++ b/lib/canonicalization.ts
@@ -59,21 +59,16 @@ export async function computeCanonicalDataset(state: GlobalState, input: InputDa
     const finalInput = async (): Promise<InputQuads> => {
         if (typeof input === 'string') {
             return await parseNquads(input as string);
-        } if (copy === undefined) {
-            if (isQuads(input)) {
-                return input;
-            } else {
-                const retval = new n3.Store();
-                for (const quad of input) retval.add(quad);
-                return retval;
-            }
         } else {
-            if (copy) {
+            const createCopy = (): InputQuads => {
                 const retval = new n3.Store();
                 for (const quad of input) retval.add(quad);
                 return retval;
+            };
+            if (copy === undefined) {
+                return isQuads(input) ? input : createCopy();
             } else {
-                return input;
+                return copy ? createCopy() : input;
             }
         }
     }

--- a/lib/common.ts
+++ b/lib/common.ts
@@ -251,6 +251,19 @@ export async function parseNquads(nquads: string): Promise<InputQuads> {
 }
 
 
+/**
+ * Type guard to see if an object implements the rdf.DatasetCore interface (a.k.a. Quads). If that is
+ * indeed the case, then the object is considered as "safe": there are no repeated terms, and it is not
+ * a generator, ie, it can be iterated on several times.
+ * 
+ * Used at the very beginning of the algorithm, part of a function that stores the quads in a local (n3) data store. By
+ * checking this, we can avoid unnecessary duplication of a dataset.
+ */
+export function isQuads(obj: any): obj is Quads {
+    // Having match is important, because all the other terms are also valid for a Set...
+    return 'has' in obj && 'match' in obj && 'add' in obj && 'delete' in obj && 'size' in obj;
+}
+
 /** 
  * Replacement of a `Set<rdf.BlankNode>` object: the build-in Set structure does not compare the RDF terms,
  * therefore does not filter out duplicate BNode instances.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdfjs-c14n",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "date": "2024-02-27",
   "description": "Implementation in Typescript of the RDF Canonicalization Algorithm RDFC-1.0, on top of the RDF/JS interfaces",
   "homepage": "https://github.com/iherman/rdfjs-c14n",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/ts-node testing/run/main.ts",
+    "gtest": "./node_modules/.bin/ts-node testing/run/generator.ts",
     "hash": "./node_modules/.bin/ts-node testing/run/hash.ts",
     "manual": "./node_modules/.bin/ts-node testing/run/manual.ts",
     "docs": "./node_modules/.bin/typedoc index.ts lib/*",

--- a/testing/run/generator.ts
+++ b/testing/run/generator.ts
@@ -1,0 +1,72 @@
+/**
+ * See original https://github.com/iherman/rdfjs-c14n/issues/13 for original bug report
+ */
+import * as n3 from 'n3';
+import * as rdf from '@rdfjs/types';
+import { RDFC10, Quads, InputQuads } from '../../index';
+
+function* createYourQuads(): Iterable<rdf.Quad> {
+    yield n3.DataFactory.quad(
+        n3.DataFactory.namedNode('http://example.org/subject'),
+        n3.DataFactory.namedNode('http://example.org/predicate'),
+        n3.DataFactory.literal('object')
+    );
+    yield n3.DataFactory.quad(
+        n3.DataFactory.namedNode('http://example.org/subject'),
+        n3.DataFactory.namedNode('http://example.org/predicate2'),
+        n3.DataFactory.literal('object2')
+    );
+}
+
+async function useGenerator() {
+    const rdfc10 = new RDFC10(n3.DataFactory);
+    const input: InputQuads = createYourQuads();
+    const normalized: Quads = (await rdfc10.c14n(input)).canonicalized_dataset;
+    console.log('Normalized dataset size:', normalized.size);
+}
+
+async function useDataset() {
+    const quads = new n3.Store();
+    quads.add(n3.DataFactory.quad(
+        n3.DataFactory.namedNode('http://example.org/subject'),
+        n3.DataFactory.namedNode('http://example.org/predicate'),
+        n3.DataFactory.literal('object')
+    ));
+    quads.add(n3.DataFactory.quad(
+        n3.DataFactory.namedNode('http://example.org/subject'),
+        n3.DataFactory.namedNode('http://example.org/predicate2'),
+        n3.DataFactory.literal('object2')
+    ));
+    const rdfc10 = new RDFC10(n3.DataFactory);
+    const normalized: Quads = (await rdfc10.c14n(quads)).canonicalized_dataset;
+    console.log('Normalized dataset size:', normalized.size);
+}
+
+async function useArray() {
+    const quads = [
+    n3.DataFactory.quad(
+        n3.DataFactory.namedNode('http://example.org/subject'),
+        n3.DataFactory.namedNode('http://example.org/predicate'),
+        n3.DataFactory.literal('object')
+    ),
+    n3.DataFactory.quad(
+        n3.DataFactory.namedNode('http://example.org/subject'),
+        n3.DataFactory.namedNode('http://example.org/predicate2'),
+        n3.DataFactory.literal('object2')
+    )];
+    const rdfc10 = new RDFC10(n3.DataFactory);
+    const normalized: Quads = (await rdfc10.c14n(quads, false)).canonicalized_dataset;
+    console.log('Normalized dataset size:', normalized.size);
+}
+
+
+async function main() {
+    console.log("Use generator");
+    await useGenerator();
+    console.log("\nUse dataset");
+    await useDataset();
+    console.log("\nUse Array");
+    await useArray();
+}
+
+main();


### PR DESCRIPTION
The problem leading to #13 is that a generator cannot be used twice, and the algorithm does go through the internal dataset several times. I.e., the input data must be copied into an internal store (much like doing it to avoid duplicate quads).

The approach on whether doing a copy or not has been slightly changed. It can be user controlled (optionally); in the absence of that control, a copy is done _unless_ the input implements the `rdf.DatasetCore` interface.

Fix #13

cc @jeswr